### PR TITLE
fix unit tests failed on lynx controller

### DIFF
--- a/pkg/controller/group/suite_test.go
+++ b/pkg/controller/group/suite_test.go
@@ -104,6 +104,8 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// disable metrics serving
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sManager).ToNot(BeNil())

--- a/pkg/webhook/validates/suite_test.go
+++ b/pkg/webhook/validates/suite_test.go
@@ -112,6 +112,8 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// disable metrics serving
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sManager).ToNot(BeNil())


### PR DESCRIPTION
When unit test, metrics start and serving on port 8080. If port 8080 has been bind, unit test will failed. So we disable the metrics serving in unit tests.

In Context "has more than 10 patches for the group", BeforeEach sometimes can't generate 10 patches because of it is possible that several endpoint update event were combined together in queue, cause failure in the test.