### PR TITLE
use hash of policyRule.Spec as flow key

### DIFF
--- a/deploy/crds/policyrule.lynx.smartx.com_policyrules.yaml
+++ b/deploy/crds/policyrule.lynx.smartx.com_policyrules.yaml
@@ -51,8 +51,6 @@ spec:
             priority:
               format: int32
               type: integer
-            ruleId:
-              type: string
             srcIpAddr:
               type: string
             srcPort:
@@ -66,7 +64,6 @@ spec:
           - direction
           - ipProtocol
           - priority
-          - ruleId
           - tcpFlags
           type: object
         status:

--- a/pkg/apis/policyrule/v1alpha1/policyrule_types.go
+++ b/pkg/apis/policyrule/v1alpha1/policyrule_types.go
@@ -47,7 +47,6 @@ type PolicyRuleList struct {
 
 // PolicyRuleSpec defines the desired state of PolicyRule
 type PolicyRuleSpec struct {
-	RuleId            string        `json:"ruleId"`
 	Direction         RuleDirection `json:"direction"`
 	DefaultPolicyRule bool          `json:"defaultPolicyRule,omitempty"`
 	Tier              string        `json:"tier,omitempty"`

--- a/pkg/controller/policy/cache/helper.go
+++ b/pkg/controller/policy/cache/helper.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cache
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -53,7 +53,7 @@ func HashName(length int, keys ...interface{}) string {
 	jsonKey, _ := json.Marshal(keys)
 	var name string
 
-	for _, char := range sha1.Sum(jsonKey) {
+	for _, char := range sha256.Sum256(jsonKey) {
 		name += string(allowRunes[int(char)%len(allowRunes)])
 	}
 

--- a/pkg/controller/policy/cache/rule.go
+++ b/pkg/controller/policy/cache/rule.go
@@ -117,11 +117,9 @@ func (rule *CompleteRule) generateRule(srcIPBlock, dstIPBlock string, port RuleP
 	ruleName := strings.Split(rule.RuleID, "/")[1]
 	policyName := strings.Split(rule.RuleID, "/")[0]
 
-	// use srcIPBlock dstIPBlock and Port as key generate hashID
-	hashID := HashName(20, srcIPBlock, dstIPBlock, port)
+	flowKey := HashName(32, policyRule.Spec)
 
-	policyRule.Name = genRuleName(policyName, ruleName, hashID)
-	policyRule.Spec.RuleId = fmt.Sprintf("%s/%s", rule.RuleID, hashID)
+	policyRule.Name = genRuleName(policyName, ruleName, flowKey)
 	policyRule.Labels = map[string]string{
 		lynxctrl.OwnerPolicyLabel: policyName,
 	}
@@ -232,9 +230,9 @@ func NewCompleteRuleCache() cache.Indexer {
 }
 
 // genRuleName generate policy rule name as defined in RFC 1123.
-func genRuleName(policyName, ruleName, ruleID string) string {
+func genRuleName(policyName, ruleName, flowKey string) string {
 	var prefix = fmt.Sprintf("%s-%s", policyName, ruleName)
-	var suffix = fmt.Sprintf("%s-%s", HashName(10, policyName, ruleName), ruleID)
+	var suffix = fmt.Sprintf("%s-%s", HashName(10, policyName, ruleName), flowKey)
 
 	maxPrefixLength := validation.DNS1123SubdomainMaxLength - len(suffix) - 1
 	if len(prefix) >= maxPrefixLength {


### PR DESCRIPTION
To prevent policy rule from adding repeatedly, use hash of policyRule.Spec as flow key.