### PR TITLE
add localendpoint accordding to local ovsdb interface status

### DIFF
--- a/cmd/lynx-agent/main.go
+++ b/cmd/lynx-agent/main.go
@@ -86,6 +86,20 @@ func main() {
 	if err != nil {
 		klog.Fatalf("error %v when start agentmonitor.", err)
 	}
+	agentmonitor.RegisterOvsdbEventHandler(monitor.OvsdbEventHandlerFuncs{
+		LocalEndpointAddFunc: func(endpoint ofnet.OfnetEndpoint) {
+			err := vlanArpLearnerAgent.GetDatapath().AddLocalEndpoint(endpoint)
+			if err != nil {
+				klog.Errorf("Failed to add local endpoint: %+v, error: %+v", endpoint, err)
+			}
+		},
+		LocalEndpointDeleteFunc: func(endpoint ofnet.OfnetEndpoint) {
+			err := vlanArpLearnerAgent.GetDatapath().RemoveLocalEndpoint(endpoint)
+			if err != nil {
+				klog.Errorf("Failed to del local endpoint: %+v, error: %+v", endpoint, err)
+			}
+		},
+	})
 	go agentmonitor.Run(stopChan)
 
 	<-stopChan


### PR DESCRIPTION
Libvirt created endpoint(VM) with specific ovsdb external-ids field named
"attached-mac" in its interface table. We use this field to monitor the local
endpoint create/delete event, and setup related local endpoint flow
