### PR TITLE
fix superfluous response.WriteHeader call

### DIFF
--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -117,5 +117,4 @@ func (v *ValidateWebhook) Handler(handle ValidateHandle) http.HandlerFunc {
 
 func (v *ValidateWebhook) healthHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "ok")
-	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
If WriteHeader has not yet been called, Write calls WriteHeader(http.StatusOK) before writing the data.
Duplicate call WriteHeader will get warning log: superfluous response.WriteHeader call ...