### PR TITLE
endpoint controller add iface indexer cache

### DIFF
--- a/pkg/controller/endpoint/endpoint_controller_test.go
+++ b/pkg/controller/endpoint/endpoint_controller_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -144,6 +145,10 @@ func newFakeReconciler(initObjs ...runtime.Object) *EndpointReconciler {
 	return &EndpointReconciler{
 		Client: fakeclient.NewFakeClientWithScheme(scheme.Scheme, initObjs...),
 		Scheme: scheme.Scheme,
+		ifaceCache: cache.NewIndexer(ifaceKeyFunc, cache.Indexers{
+			agentIndex:      agentIndexFunc,
+			externalIDIndex: externalIDIndexFunc,
+		}),
 	}
 }
 

--- a/pkg/webhook/validates/crd_validate.go
+++ b/pkg/webhook/validates/crd_validate.go
@@ -266,7 +266,7 @@ func (v endpointValidator) updateValidate(oldObj, curObj runtime.Object, userInf
 	curEndpoint := curObj.(*securityv1alpha1.Endpoint)
 	oldEndpoint := oldObj.(*securityv1alpha1.Endpoint)
 
-	if curEndpoint.Spec != oldEndpoint.Spec {
+	if curEndpoint.Spec.Reference != oldEndpoint.Spec.Reference {
 		return "update endpoint externalID not allowed", false
 	}
 	return "", true


### PR DESCRIPTION
This PR:
1. Add iface indexer cache for endpoint controller, improve the efficiency of fetch endpoint status. #94 
2. Fix and add endpoint controller test cases.
3. Fix validate webhook on endpoint update.