### PR TITLE
Fix infinite loop caused by uint64 overflow

### DIFF
--- a/pkg/controller/policy/policy_controller.go
+++ b/pkg/controller/policy/policy_controller.go
@@ -628,9 +628,12 @@ func flattenPorts(ports []securityv1alpha1.SecurityPolicyPort) ([]policycache.Ru
 			return nil, fmt.Errorf("portrange %s unavailable: %s", port.PortRange, err)
 		}
 
-		for portNumber := begin; portNumber <= end; portNumber++ {
+		// If defined portNumber as type uint16 here, an infinite loop will occur when end is
+		// 65535 (uint16 value will never bigger than 65535, for condition would always true).
+		// So we defined portNumber as type int here.
+		for portNumber := int(begin); portNumber <= int(end); portNumber++ {
 			portItem := policycache.RulePort{
-				DstPort:  portNumber,
+				DstPort:  uint16(portNumber),
 				Protocol: port.Protocol,
 			}
 			rulePortMap[portItem] = struct{}{}

--- a/tests/e2e/cases/security_mode.go
+++ b/tests/e2e/cases/security_mode.go
@@ -209,9 +209,9 @@ func flattenPorts(ports []securityv1alpha1.SecurityPolicyPort) ([]cache.RulePort
 			return nil, fmt.Errorf("portrange %s unavailable: %s", port.PortRange, err)
 		}
 
-		for portNumber := begin; portNumber <= end; portNumber++ {
+		for portNumber := int(begin); portNumber <= int(end); portNumber++ {
 			portItem := cache.RulePort{
-				DstPort:  portNumber,
+				DstPort:  uint16(portNumber),
 				Protocol: port.Protocol,
 			}
 			rulePortMap[portItem] = struct{}{}


### PR DESCRIPTION
In code `for portNumber := begin; portNumber <= end; portNumber++`, loop continues while `portNumber <= end`.
If `end = 65535`, the loop won't stop because of int16 is always smaller than 65535.

Signed-off-by: zwtop <wang.zhan@smartx.com>