### PR TITLE
fix(plugin-tower): delete object get nil object value

### DIFF
--- a/plugin/tower/pkg/client/types.go
+++ b/plugin/tower/pkg/client/types.go
@@ -93,8 +93,9 @@ type UserInfo struct {
 
 // MutationEvent is the event subscribed from tower
 type MutationEvent struct {
-	Mutation MutationType    `json:"mutation"`
-	Node     json.RawMessage `json:"node"`
+	Mutation       MutationType    `json:"mutation"`
+	PreviousValues json.RawMessage `json:"previousValues"`
+	Node           json.RawMessage `json:"node"`
 }
 
 type MutationType string


### PR DESCRIPTION
When subscript objects from the tower, delete object may get an event with nil object. So we get the delete object id from filed previousValues.