### PR TITLE
Add namespace for endpoint and securitypolicy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,9 @@ linters-settings:
     ignore: fmt:.*,io/ioutil:^Read.*,io:Close
   lll:
     line-length: 170
+  funlen:
+    lines: 80
+    statements: 60
 
 run:
   timeout: 10m

--- a/deploy/crds/security.lynx.smartx.com_endpoints.yaml
+++ b/deploy/crds/security.lynx.smartx.com_endpoints.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: EndpointList
     plural: endpoints
     singular: endpoint
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:

--- a/deploy/crds/security.lynx.smartx.com_securitypolicies.yaml
+++ b/deploy/crds/security.lynx.smartx.com_securitypolicies.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: SecurityPolicyList
     plural: securitypolicies
     singular: securitypolicy
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:

--- a/pkg/apis/security/v1alpha1/types.go
+++ b/pkg/apis/security/v1alpha1/types.go
@@ -230,11 +230,8 @@ type Endpoint struct {
 }
 
 type EndpointSpec struct {
-	// Lynx allows endpoints from different sources, we distinguish the source
-	// of endpoint by field ManagePlaneID.
-	ManagePlaneID string            `json:"managePlaneID,omitempty"`
-	VID           uint32            `json:"vid"`
-	Reference     EndpointReference `json:"reference"`
+	VID       uint32            `json:"vid"`
+	Reference EndpointReference `json:"reference"`
 }
 
 type EndpointReference struct {

--- a/pkg/apis/security/v1alpha1/types.go
+++ b/pkg/apis/security/v1alpha1/types.go
@@ -22,11 +22,9 @@ import (
 )
 
 // +genclient
-// +genclient:nonNamespaced
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
 
 type SecurityPolicy struct {
@@ -218,11 +216,9 @@ type TierList struct {
 }
 
 // +genclient
-// +genclient:nonNamespaced
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
 
 type Endpoint struct {

--- a/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/endpoint.go
+++ b/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/endpoint.go
@@ -33,7 +33,7 @@ import (
 // EndpointsGetter has a method to return a EndpointInterface.
 // A group's client should implement this interface.
 type EndpointsGetter interface {
-	Endpoints() EndpointInterface
+	Endpoints(namespace string) EndpointInterface
 }
 
 // EndpointInterface has methods to work with Endpoint resources.
@@ -53,12 +53,14 @@ type EndpointInterface interface {
 // endpoints implements EndpointInterface
 type endpoints struct {
 	client rest.Interface
+	ns     string
 }
 
 // newEndpoints returns a Endpoints
-func newEndpoints(c *SecurityV1alpha1Client) *endpoints {
+func newEndpoints(c *SecurityV1alpha1Client, namespace string) *endpoints {
 	return &endpoints{
 		client: c.RESTClient(),
+		ns:     namespace,
 	}
 }
 
@@ -66,6 +68,7 @@ func newEndpoints(c *SecurityV1alpha1Client) *endpoints {
 func (c *endpoints) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Endpoint, err error) {
 	result = &v1alpha1.Endpoint{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("endpoints").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -82,6 +85,7 @@ func (c *endpoints) List(ctx context.Context, opts v1.ListOptions) (result *v1al
 	}
 	result = &v1alpha1.EndpointList{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("endpoints").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -98,6 +102,7 @@ func (c *endpoints) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 	}
 	opts.Watch = true
 	return c.client.Get().
+		Namespace(c.ns).
 		Resource("endpoints").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +113,7 @@ func (c *endpoints) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inter
 func (c *endpoints) Create(ctx context.Context, endpoint *v1alpha1.Endpoint, opts v1.CreateOptions) (result *v1alpha1.Endpoint, err error) {
 	result = &v1alpha1.Endpoint{}
 	err = c.client.Post().
+		Namespace(c.ns).
 		Resource("endpoints").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(endpoint).
@@ -120,6 +126,7 @@ func (c *endpoints) Create(ctx context.Context, endpoint *v1alpha1.Endpoint, opt
 func (c *endpoints) Update(ctx context.Context, endpoint *v1alpha1.Endpoint, opts v1.UpdateOptions) (result *v1alpha1.Endpoint, err error) {
 	result = &v1alpha1.Endpoint{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("endpoints").
 		Name(endpoint.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -134,6 +141,7 @@ func (c *endpoints) Update(ctx context.Context, endpoint *v1alpha1.Endpoint, opt
 func (c *endpoints) UpdateStatus(ctx context.Context, endpoint *v1alpha1.Endpoint, opts v1.UpdateOptions) (result *v1alpha1.Endpoint, err error) {
 	result = &v1alpha1.Endpoint{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("endpoints").
 		Name(endpoint.Name).
 		SubResource("status").
@@ -147,6 +155,7 @@ func (c *endpoints) UpdateStatus(ctx context.Context, endpoint *v1alpha1.Endpoin
 // Delete takes name of the endpoint and deletes it. Returns an error if one occurs.
 func (c *endpoints) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("endpoints").
 		Name(name).
 		Body(&opts).
@@ -161,6 +170,7 @@ func (c *endpoints) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("endpoints").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -173,6 +183,7 @@ func (c *endpoints) DeleteCollection(ctx context.Context, opts v1.DeleteOptions,
 func (c *endpoints) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Endpoint, err error) {
 	result = &v1alpha1.Endpoint{}
 	err = c.client.Patch(pt).
+		Namespace(c.ns).
 		Resource("endpoints").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/fake/fake_endpoint.go
+++ b/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/fake/fake_endpoint.go
@@ -33,6 +33,7 @@ import (
 // FakeEndpoints implements EndpointInterface
 type FakeEndpoints struct {
 	Fake *FakeSecurityV1alpha1
+	ns   string
 }
 
 var endpointsResource = schema.GroupVersionResource{Group: "security.lynx.smartx.com", Version: "v1alpha1", Resource: "endpoints"}
@@ -42,7 +43,8 @@ var endpointsKind = schema.GroupVersionKind{Group: "security.lynx.smartx.com", V
 // Get takes name of the endpoint, and returns the corresponding endpoint object, and an error if there is any.
 func (c *FakeEndpoints) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Endpoint, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(endpointsResource, name), &v1alpha1.Endpoint{})
+		Invokes(testing.NewGetAction(endpointsResource, c.ns, name), &v1alpha1.Endpoint{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -52,7 +54,8 @@ func (c *FakeEndpoints) Get(ctx context.Context, name string, options v1.GetOpti
 // List takes label and field selectors, and returns the list of Endpoints that match those selectors.
 func (c *FakeEndpoints) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.EndpointList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(endpointsResource, endpointsKind, opts), &v1alpha1.EndpointList{})
+		Invokes(testing.NewListAction(endpointsResource, endpointsKind, c.ns, opts), &v1alpha1.EndpointList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -73,13 +76,15 @@ func (c *FakeEndpoints) List(ctx context.Context, opts v1.ListOptions) (result *
 // Watch returns a watch.Interface that watches the requested endpoints.
 func (c *FakeEndpoints) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(endpointsResource, opts))
+		InvokesWatch(testing.NewWatchAction(endpointsResource, c.ns, opts))
+
 }
 
 // Create takes the representation of a endpoint and creates it.  Returns the server's representation of the endpoint, and an error, if there is any.
 func (c *FakeEndpoints) Create(ctx context.Context, endpoint *v1alpha1.Endpoint, opts v1.CreateOptions) (result *v1alpha1.Endpoint, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(endpointsResource, endpoint), &v1alpha1.Endpoint{})
+		Invokes(testing.NewCreateAction(endpointsResource, c.ns, endpoint), &v1alpha1.Endpoint{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -89,7 +94,8 @@ func (c *FakeEndpoints) Create(ctx context.Context, endpoint *v1alpha1.Endpoint,
 // Update takes the representation of a endpoint and updates it. Returns the server's representation of the endpoint, and an error, if there is any.
 func (c *FakeEndpoints) Update(ctx context.Context, endpoint *v1alpha1.Endpoint, opts v1.UpdateOptions) (result *v1alpha1.Endpoint, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(endpointsResource, endpoint), &v1alpha1.Endpoint{})
+		Invokes(testing.NewUpdateAction(endpointsResource, c.ns, endpoint), &v1alpha1.Endpoint{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -100,7 +106,8 @@ func (c *FakeEndpoints) Update(ctx context.Context, endpoint *v1alpha1.Endpoint,
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeEndpoints) UpdateStatus(ctx context.Context, endpoint *v1alpha1.Endpoint, opts v1.UpdateOptions) (*v1alpha1.Endpoint, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(endpointsResource, "status", endpoint), &v1alpha1.Endpoint{})
+		Invokes(testing.NewUpdateSubresourceAction(endpointsResource, "status", c.ns, endpoint), &v1alpha1.Endpoint{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -110,13 +117,14 @@ func (c *FakeEndpoints) UpdateStatus(ctx context.Context, endpoint *v1alpha1.End
 // Delete takes name of the endpoint and deletes it. Returns an error if one occurs.
 func (c *FakeEndpoints) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(endpointsResource, name), &v1alpha1.Endpoint{})
+		Invokes(testing.NewDeleteAction(endpointsResource, c.ns, name), &v1alpha1.Endpoint{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeEndpoints) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(endpointsResource, listOpts)
+	action := testing.NewDeleteCollectionAction(endpointsResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.EndpointList{})
 	return err
@@ -125,7 +133,8 @@ func (c *FakeEndpoints) DeleteCollection(ctx context.Context, opts v1.DeleteOpti
 // Patch applies the patch and returns the patched endpoint.
 func (c *FakeEndpoints) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Endpoint, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(endpointsResource, name, pt, data, subresources...), &v1alpha1.Endpoint{})
+		Invokes(testing.NewPatchSubresourceAction(endpointsResource, c.ns, name, pt, data, subresources...), &v1alpha1.Endpoint{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/fake/fake_security_client.go
+++ b/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/fake/fake_security_client.go
@@ -28,12 +28,12 @@ type FakeSecurityV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeSecurityV1alpha1) Endpoints() v1alpha1.EndpointInterface {
-	return &FakeEndpoints{c}
+func (c *FakeSecurityV1alpha1) Endpoints(namespace string) v1alpha1.EndpointInterface {
+	return &FakeEndpoints{c, namespace}
 }
 
-func (c *FakeSecurityV1alpha1) SecurityPolicies() v1alpha1.SecurityPolicyInterface {
-	return &FakeSecurityPolicies{c}
+func (c *FakeSecurityV1alpha1) SecurityPolicies(namespace string) v1alpha1.SecurityPolicyInterface {
+	return &FakeSecurityPolicies{c, namespace}
 }
 
 func (c *FakeSecurityV1alpha1) Tiers() v1alpha1.TierInterface {

--- a/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/fake/fake_securitypolicy.go
+++ b/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/fake/fake_securitypolicy.go
@@ -33,6 +33,7 @@ import (
 // FakeSecurityPolicies implements SecurityPolicyInterface
 type FakeSecurityPolicies struct {
 	Fake *FakeSecurityV1alpha1
+	ns   string
 }
 
 var securitypoliciesResource = schema.GroupVersionResource{Group: "security.lynx.smartx.com", Version: "v1alpha1", Resource: "securitypolicies"}
@@ -42,7 +43,8 @@ var securitypoliciesKind = schema.GroupVersionKind{Group: "security.lynx.smartx.
 // Get takes name of the securityPolicy, and returns the corresponding securityPolicy object, and an error if there is any.
 func (c *FakeSecurityPolicies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.SecurityPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(securitypoliciesResource, name), &v1alpha1.SecurityPolicy{})
+		Invokes(testing.NewGetAction(securitypoliciesResource, c.ns, name), &v1alpha1.SecurityPolicy{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -52,7 +54,8 @@ func (c *FakeSecurityPolicies) Get(ctx context.Context, name string, options v1.
 // List takes label and field selectors, and returns the list of SecurityPolicies that match those selectors.
 func (c *FakeSecurityPolicies) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.SecurityPolicyList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(securitypoliciesResource, securitypoliciesKind, opts), &v1alpha1.SecurityPolicyList{})
+		Invokes(testing.NewListAction(securitypoliciesResource, securitypoliciesKind, c.ns, opts), &v1alpha1.SecurityPolicyList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -73,13 +76,15 @@ func (c *FakeSecurityPolicies) List(ctx context.Context, opts v1.ListOptions) (r
 // Watch returns a watch.Interface that watches the requested securityPolicies.
 func (c *FakeSecurityPolicies) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(securitypoliciesResource, opts))
+		InvokesWatch(testing.NewWatchAction(securitypoliciesResource, c.ns, opts))
+
 }
 
 // Create takes the representation of a securityPolicy and creates it.  Returns the server's representation of the securityPolicy, and an error, if there is any.
 func (c *FakeSecurityPolicies) Create(ctx context.Context, securityPolicy *v1alpha1.SecurityPolicy, opts v1.CreateOptions) (result *v1alpha1.SecurityPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(securitypoliciesResource, securityPolicy), &v1alpha1.SecurityPolicy{})
+		Invokes(testing.NewCreateAction(securitypoliciesResource, c.ns, securityPolicy), &v1alpha1.SecurityPolicy{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -89,7 +94,8 @@ func (c *FakeSecurityPolicies) Create(ctx context.Context, securityPolicy *v1alp
 // Update takes the representation of a securityPolicy and updates it. Returns the server's representation of the securityPolicy, and an error, if there is any.
 func (c *FakeSecurityPolicies) Update(ctx context.Context, securityPolicy *v1alpha1.SecurityPolicy, opts v1.UpdateOptions) (result *v1alpha1.SecurityPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(securitypoliciesResource, securityPolicy), &v1alpha1.SecurityPolicy{})
+		Invokes(testing.NewUpdateAction(securitypoliciesResource, c.ns, securityPolicy), &v1alpha1.SecurityPolicy{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -100,7 +106,8 @@ func (c *FakeSecurityPolicies) Update(ctx context.Context, securityPolicy *v1alp
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeSecurityPolicies) UpdateStatus(ctx context.Context, securityPolicy *v1alpha1.SecurityPolicy, opts v1.UpdateOptions) (*v1alpha1.SecurityPolicy, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(securitypoliciesResource, "status", securityPolicy), &v1alpha1.SecurityPolicy{})
+		Invokes(testing.NewUpdateSubresourceAction(securitypoliciesResource, "status", c.ns, securityPolicy), &v1alpha1.SecurityPolicy{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -110,13 +117,14 @@ func (c *FakeSecurityPolicies) UpdateStatus(ctx context.Context, securityPolicy 
 // Delete takes name of the securityPolicy and deletes it. Returns an error if one occurs.
 func (c *FakeSecurityPolicies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(securitypoliciesResource, name), &v1alpha1.SecurityPolicy{})
+		Invokes(testing.NewDeleteAction(securitypoliciesResource, c.ns, name), &v1alpha1.SecurityPolicy{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeSecurityPolicies) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(securitypoliciesResource, listOpts)
+	action := testing.NewDeleteCollectionAction(securitypoliciesResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.SecurityPolicyList{})
 	return err
@@ -125,7 +133,8 @@ func (c *FakeSecurityPolicies) DeleteCollection(ctx context.Context, opts v1.Del
 // Patch applies the patch and returns the patched securityPolicy.
 func (c *FakeSecurityPolicies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.SecurityPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(securitypoliciesResource, name, pt, data, subresources...), &v1alpha1.SecurityPolicy{})
+		Invokes(testing.NewPatchSubresourceAction(securitypoliciesResource, c.ns, name, pt, data, subresources...), &v1alpha1.SecurityPolicy{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/security_client.go
+++ b/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/security_client.go
@@ -36,12 +36,12 @@ type SecurityV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *SecurityV1alpha1Client) Endpoints() EndpointInterface {
-	return newEndpoints(c)
+func (c *SecurityV1alpha1Client) Endpoints(namespace string) EndpointInterface {
+	return newEndpoints(c, namespace)
 }
 
-func (c *SecurityV1alpha1Client) SecurityPolicies() SecurityPolicyInterface {
-	return newSecurityPolicies(c)
+func (c *SecurityV1alpha1Client) SecurityPolicies(namespace string) SecurityPolicyInterface {
+	return newSecurityPolicies(c, namespace)
 }
 
 func (c *SecurityV1alpha1Client) Tiers() TierInterface {

--- a/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/securitypolicy.go
+++ b/pkg/client/clientset_generated/clientset/typed/security/v1alpha1/securitypolicy.go
@@ -33,7 +33,7 @@ import (
 // SecurityPoliciesGetter has a method to return a SecurityPolicyInterface.
 // A group's client should implement this interface.
 type SecurityPoliciesGetter interface {
-	SecurityPolicies() SecurityPolicyInterface
+	SecurityPolicies(namespace string) SecurityPolicyInterface
 }
 
 // SecurityPolicyInterface has methods to work with SecurityPolicy resources.
@@ -53,12 +53,14 @@ type SecurityPolicyInterface interface {
 // securityPolicies implements SecurityPolicyInterface
 type securityPolicies struct {
 	client rest.Interface
+	ns     string
 }
 
 // newSecurityPolicies returns a SecurityPolicies
-func newSecurityPolicies(c *SecurityV1alpha1Client) *securityPolicies {
+func newSecurityPolicies(c *SecurityV1alpha1Client, namespace string) *securityPolicies {
 	return &securityPolicies{
 		client: c.RESTClient(),
+		ns:     namespace,
 	}
 }
 
@@ -66,6 +68,7 @@ func newSecurityPolicies(c *SecurityV1alpha1Client) *securityPolicies {
 func (c *securityPolicies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.SecurityPolicy, err error) {
 	result = &v1alpha1.SecurityPolicy{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("securitypolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -82,6 +85,7 @@ func (c *securityPolicies) List(ctx context.Context, opts v1.ListOptions) (resul
 	}
 	result = &v1alpha1.SecurityPolicyList{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("securitypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -98,6 +102,7 @@ func (c *securityPolicies) Watch(ctx context.Context, opts v1.ListOptions) (watc
 	}
 	opts.Watch = true
 	return c.client.Get().
+		Namespace(c.ns).
 		Resource("securitypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -108,6 +113,7 @@ func (c *securityPolicies) Watch(ctx context.Context, opts v1.ListOptions) (watc
 func (c *securityPolicies) Create(ctx context.Context, securityPolicy *v1alpha1.SecurityPolicy, opts v1.CreateOptions) (result *v1alpha1.SecurityPolicy, err error) {
 	result = &v1alpha1.SecurityPolicy{}
 	err = c.client.Post().
+		Namespace(c.ns).
 		Resource("securitypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(securityPolicy).
@@ -120,6 +126,7 @@ func (c *securityPolicies) Create(ctx context.Context, securityPolicy *v1alpha1.
 func (c *securityPolicies) Update(ctx context.Context, securityPolicy *v1alpha1.SecurityPolicy, opts v1.UpdateOptions) (result *v1alpha1.SecurityPolicy, err error) {
 	result = &v1alpha1.SecurityPolicy{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("securitypolicies").
 		Name(securityPolicy.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -134,6 +141,7 @@ func (c *securityPolicies) Update(ctx context.Context, securityPolicy *v1alpha1.
 func (c *securityPolicies) UpdateStatus(ctx context.Context, securityPolicy *v1alpha1.SecurityPolicy, opts v1.UpdateOptions) (result *v1alpha1.SecurityPolicy, err error) {
 	result = &v1alpha1.SecurityPolicy{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("securitypolicies").
 		Name(securityPolicy.Name).
 		SubResource("status").
@@ -147,6 +155,7 @@ func (c *securityPolicies) UpdateStatus(ctx context.Context, securityPolicy *v1a
 // Delete takes name of the securityPolicy and deletes it. Returns an error if one occurs.
 func (c *securityPolicies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("securitypolicies").
 		Name(name).
 		Body(&opts).
@@ -161,6 +170,7 @@ func (c *securityPolicies) DeleteCollection(ctx context.Context, opts v1.DeleteO
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("securitypolicies").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -173,6 +183,7 @@ func (c *securityPolicies) DeleteCollection(ctx context.Context, opts v1.DeleteO
 func (c *securityPolicies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.SecurityPolicy, err error) {
 	result = &v1alpha1.SecurityPolicy{}
 	err = c.client.Patch(pt).
+		Namespace(c.ns).
 		Resource("securitypolicies").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/client/informers_generated/externalversions/security/v1alpha1/endpoint.go
+++ b/pkg/client/informers_generated/externalversions/security/v1alpha1/endpoint.go
@@ -42,32 +42,33 @@ type EndpointInformer interface {
 type endpointInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	namespace        string
 }
 
 // NewEndpointInformer constructs a new informer for Endpoint type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewEndpointInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredEndpointInformer(client, resyncPeriod, indexers, nil)
+func NewEndpointInformer(client clientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredEndpointInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredEndpointInformer constructs a new informer for Endpoint type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredEndpointInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredEndpointInformer(client clientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecurityV1alpha1().Endpoints().List(context.TODO(), options)
+				return client.SecurityV1alpha1().Endpoints(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecurityV1alpha1().Endpoints().Watch(context.TODO(), options)
+				return client.SecurityV1alpha1().Endpoints(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&securityv1alpha1.Endpoint{},
@@ -77,7 +78,7 @@ func NewFilteredEndpointInformer(client clientset.Interface, resyncPeriod time.D
 }
 
 func (f *endpointInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredEndpointInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredEndpointInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *endpointInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers_generated/externalversions/security/v1alpha1/interface.go
+++ b/pkg/client/informers_generated/externalversions/security/v1alpha1/interface.go
@@ -45,12 +45,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // Endpoints returns a EndpointInformer.
 func (v *version) Endpoints() EndpointInformer {
-	return &endpointInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &endpointInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
 // SecurityPolicies returns a SecurityPolicyInformer.
 func (v *version) SecurityPolicies() SecurityPolicyInformer {
-	return &securityPolicyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &securityPolicyInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
 // Tiers returns a TierInformer.

--- a/pkg/client/informers_generated/externalversions/security/v1alpha1/securitypolicy.go
+++ b/pkg/client/informers_generated/externalversions/security/v1alpha1/securitypolicy.go
@@ -42,32 +42,33 @@ type SecurityPolicyInformer interface {
 type securityPolicyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	namespace        string
 }
 
 // NewSecurityPolicyInformer constructs a new informer for SecurityPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewSecurityPolicyInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredSecurityPolicyInformer(client, resyncPeriod, indexers, nil)
+func NewSecurityPolicyInformer(client clientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredSecurityPolicyInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredSecurityPolicyInformer constructs a new informer for SecurityPolicy type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredSecurityPolicyInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredSecurityPolicyInformer(client clientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecurityV1alpha1().SecurityPolicies().List(context.TODO(), options)
+				return client.SecurityV1alpha1().SecurityPolicies(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.SecurityV1alpha1().SecurityPolicies().Watch(context.TODO(), options)
+				return client.SecurityV1alpha1().SecurityPolicies(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&securityv1alpha1.SecurityPolicy{},
@@ -77,7 +78,7 @@ func NewFilteredSecurityPolicyInformer(client clientset.Interface, resyncPeriod 
 }
 
 func (f *securityPolicyInformer) defaultInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredSecurityPolicyInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredSecurityPolicyInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *securityPolicyInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/listers_generated/security/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers_generated/security/v1alpha1/expansion_generated.go
@@ -22,9 +22,17 @@ package v1alpha1
 // EndpointLister.
 type EndpointListerExpansion interface{}
 
+// EndpointNamespaceListerExpansion allows custom methods to be added to
+// EndpointNamespaceLister.
+type EndpointNamespaceListerExpansion interface{}
+
 // SecurityPolicyListerExpansion allows custom methods to be added to
 // SecurityPolicyLister.
 type SecurityPolicyListerExpansion interface{}
+
+// SecurityPolicyNamespaceListerExpansion allows custom methods to be added to
+// SecurityPolicyNamespaceLister.
+type SecurityPolicyNamespaceListerExpansion interface{}
 
 // TierListerExpansion allows custom methods to be added to
 // TierLister.

--- a/pkg/controller/group/group_controller_test.go
+++ b/pkg/controller/group/group_controller_test.go
@@ -55,8 +55,10 @@ var _ = Describe("GroupController", func() {
 	})
 
 	AfterEach(func() {
+		namespaceDefault := client.InNamespace(metav1.NamespaceDefault)
+
 		By("delete all test endpoints")
-		Expect(k8sClient.DeleteAllOf(ctx, &securityv1alpha1.Endpoint{}, client.MatchingLabels{TestLabelKey: TestLabelValue})).Should(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, &securityv1alpha1.Endpoint{}, namespaceDefault, client.MatchingLabels{TestLabelKey: TestLabelValue})).Should(Succeed())
 		Eventually(func() int {
 			epList := securityv1alpha1.EndpointList{}
 			Expect(k8sClient.List(ctx, &epList)).Should(Succeed())
@@ -286,8 +288,9 @@ func newTestEndpoint(labels map[string]string, ip types.IPAddress) *securityv1al
 
 	return &securityv1alpha1.Endpoint{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+			Labels:    labels,
 		},
 		Spec: securityv1alpha1.EndpointSpec{
 			Reference: securityv1alpha1.EndpointReference{

--- a/pkg/controller/policy/policy_controller_test.go
+++ b/pkg/controller/policy/policy_controller_test.go
@@ -61,8 +61,10 @@ var _ = Describe("PolicyController", func() {
 	})
 
 	AfterEach(func() {
+		namespaceDefault := client.InNamespace(metav1.NamespaceDefault)
+
 		By("delete all test policies")
-		Expect(k8sClient.DeleteAllOf(ctx, &securityv1alpha1.SecurityPolicy{}, client.MatchingLabels{TestLabelKey: TestLabelValue})).Should(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, &securityv1alpha1.SecurityPolicy{}, namespaceDefault, client.MatchingLabels{TestLabelKey: TestLabelValue})).Should(Succeed())
 		Eventually(func() int {
 			policyList := securityv1alpha1.SecurityPolicyList{}
 			Expect(k8sClient.List(ctx, &policyList)).Should(Succeed())
@@ -705,7 +707,7 @@ func newTestPolicy(appliedToGroup, ingressGroup, egressGroup string, ingressPort
 	return &securityv1alpha1.SecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: metav1.NamespaceNone,
+			Namespace: metav1.NamespaceDefault,
 			Labels:    map[string]string{TestLabelKey: TestLabelValue},
 		},
 		Spec: securityv1alpha1.SecurityPolicySpec{
@@ -745,7 +747,7 @@ func newTestEndpoint(ip types.IPAddress) *securityv1alpha1.Endpoint {
 	return &securityv1alpha1.Endpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: metav1.NamespaceNone,
+			Namespace: metav1.NamespaceDefault,
 			Labels:    map[string]string{TestLabelKey: TestLabelValue},
 		},
 		Spec: securityv1alpha1.EndpointSpec{
@@ -831,7 +833,7 @@ func mustUpdatePolicy(ctx context.Context, policy *securityv1alpha1.SecurityPoli
 	var oldPolicy = &securityv1alpha1.SecurityPolicy{}
 
 	Eventually(func() error {
-		err := k8sClient.Get(ctx, k8stypes.NamespacedName{Name: policy.Name}, oldPolicy)
+		err := k8sClient.Get(ctx, k8stypes.NamespacedName{Name: policy.GetName(), Namespace: policy.GetNamespace()}, oldPolicy)
 		if err != nil {
 			return err
 		}

--- a/plugin/tower/cmd/main.go
+++ b/plugin/tower/cmd/main.go
@@ -61,7 +61,7 @@ func run(options *Options) error {
 	towerFactory := informer.NewSharedInformerFactory(options.Config.Client, resyncPeriod)
 	crdFactory := externalversions.NewSharedInformerFactory(crdClient, resyncPeriod)
 
-	endpointController := controller.New(towerFactory, crdFactory, crdClient, resyncPeriod)
+	endpointController := controller.New(towerFactory, crdFactory, crdClient, resyncPeriod, options.Config.Controller.Namespace)
 
 	towerFactory.Start(stopCh)
 	crdFactory.Start(stopCh)

--- a/plugin/tower/cmd/options.go
+++ b/plugin/tower/cmd/options.go
@@ -49,8 +49,9 @@ type LeaderElectionConfig struct {
 }
 
 type ControllerConfig struct {
-	Resync  time.Duration `yaml:"resync"`
-	Workers uint          `yaml:"workers"`
+	Resync    time.Duration `yaml:"resync"`
+	Workers   uint          `yaml:"workers"`
+	Namespace string        `yaml:"namespace"`
 }
 
 func (o *Options) LoadFromFile(kubeconfig string, configfile string) error {
@@ -93,8 +94,9 @@ func (o *Options) setDefault() {
 
 	if o.Config.Controller == nil {
 		o.Config.Controller = &ControllerConfig{
-			Resync:  0,
-			Workers: 10,
+			Resync:    0,
+			Workers:   10,
+			Namespace: "tower-space",
 		}
 	}
 }

--- a/plugin/tower/pkg/controller/controller_test.go
+++ b/plugin/tower/pkg/controller/controller_test.go
@@ -38,6 +38,7 @@ import (
 var (
 	crdClient clientset.Interface
 	server    *fakeserver.Server
+	namespace = metav1.NamespaceDefault
 )
 
 func TestMain(m *testing.M) {
@@ -50,7 +51,7 @@ func TestMain(m *testing.M) {
 	towerFactory := informer.NewSharedInformerFactory(server.NewClient(), 0)
 	crdFactory := externalversions.NewSharedInformerFactory(crdClient, 0)
 
-	ctroller := New(towerFactory, crdFactory, crdClient, 0)
+	ctroller := New(towerFactory, crdFactory, crdClient, 0, namespace)
 	go ctroller.Run(10, stopCh)
 
 	towerFactory.Start(stopCh)
@@ -74,7 +75,7 @@ func TestHandlerEndpoint(t *testing.T) {
 	}
 
 	Eventually(func() bool {
-		epList, err := crdClient.SecurityV1alpha1().Endpoints().List(context.Background(), metav1.ListOptions{})
+		epList, err := crdClient.SecurityV1alpha1().Endpoints(namespace).List(context.Background(), metav1.ListOptions{})
 		return len(epList.Items) == numOfRandVM && err == nil
 	}, time.Minute, 100*time.Millisecond).Should(BeTrue())
 }

--- a/tests/e2e/cases/security_test.go
+++ b/tests/e2e/cases/security_test.go
@@ -523,6 +523,7 @@ func newGroup(name string, selector map[string]string) *groupv1alpha1.EndpointGr
 func newPolicy(name, tier string, priority int32, appliedGroup []string, endpoints []string) *securityv1alpha1.SecurityPolicy {
 	policy := &securityv1alpha1.SecurityPolicy{}
 	policy.Name = name
+	policy.Namespace = metav1.NamespaceDefault
 
 	policy.Spec = securityv1alpha1.SecurityPolicySpec{
 		Tier:     tier,

--- a/tests/e2e/framework/endpoint/netns/provider.go
+++ b/tests/e2e/framework/endpoint/netns/provider.go
@@ -66,7 +66,7 @@ func (m *provider) Get(ctx context.Context, name string) (*model.Endpoint, error
 func (m *provider) List(ctx context.Context) ([]*model.Endpoint, error) {
 	var epList []*model.Endpoint
 
-	list, err := m.kubeClient.SecurityV1alpha1().Endpoints().List(ctx, metav1.ListOptions{})
+	list, err := m.kubeClient.SecurityV1alpha1().Endpoints(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (m *provider) Create(ctx context.Context, endpoint *model.Endpoint) (*model
 		return nil, fmt.Errorf("failed build endpoint %s status: %s", endpoint.Name, err)
 	}
 
-	_, err = m.kubeClient.SecurityV1alpha1().Endpoints().Create(ctx, toCrdEndpoint(endpoint, ""), metav1.CreateOptions{})
+	_, err = m.kubeClient.SecurityV1alpha1().Endpoints(metav1.NamespaceDefault).Create(ctx, toCrdEndpoint(endpoint, ""), metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("unable create endpoint %s: %s", endpoint.Name, err)
 	}
@@ -151,7 +151,7 @@ func (m *provider) Delete(ctx context.Context, name string) error {
 		return fmt.Errorf("unable delete endpoint %s on agent %s: %s", endpoint.Name, endpoint.Status.Host, err)
 	}
 
-	return m.kubeClient.SecurityV1alpha1().Endpoints().Delete(ctx, name, metav1.DeleteOptions{})
+	return m.kubeClient.SecurityV1alpha1().Endpoints(metav1.NamespaceDefault).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 func (m *provider) RenewIP(ctx context.Context, name string) (*model.Endpoint, error) {
@@ -253,7 +253,7 @@ func (m *provider) updateEndpoint(ctx context.Context, endpoint *model.Endpoint,
 
 	for {
 		crdEp := toCrdEndpoint(endpoint, rv)
-		_, err = m.kubeClient.SecurityV1alpha1().Endpoints().Update(ctx, crdEp, metav1.UpdateOptions{})
+		_, err = m.kubeClient.SecurityV1alpha1().Endpoints(metav1.NamespaceDefault).Update(ctx, crdEp, metav1.UpdateOptions{})
 
 		if err != nil && apierrors.IsConflict(err) {
 			// if got error StatusReasonConflict, fetch resource version and try again
@@ -269,7 +269,7 @@ func (m *provider) updateEndpoint(ctx context.Context, endpoint *model.Endpoint,
 }
 
 func (m *provider) getEndpoint(ctx context.Context, name string) (*model.Endpoint, string, error) {
-	crdEp, err := m.kubeClient.SecurityV1alpha1().Endpoints().Get(ctx, name, metav1.GetOptions{})
+	crdEp, err := m.kubeClient.SecurityV1alpha1().Endpoints(metav1.NamespaceDefault).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -380,7 +380,6 @@ func toCrdEndpoint(endpoint *model.Endpoint, resourceVersion string) *v1alpha1.E
 	securityEp.Annotations = map[string]string{endpointLastStatusAnnotation: string(data)}
 
 	securityEp.Spec = v1alpha1.EndpointSpec{
-		ManagePlaneID: "lynx.e2e.netns.endpoint-provider",
 		Reference: v1alpha1.EndpointReference{
 			ExternalIDName:  "external_uuid",
 			ExternalIDValue: fmt.Sprintf("uuid-%s", endpoint.Status.LocalID),

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -134,7 +134,7 @@ func (f *Framework) ResetResource(ctx context.Context) error {
 		return fmt.Errorf("clean endpoints: %s", err)
 	}
 
-	err = f.kubeClient.DeleteAllOf(ctx, &securityv1alpha1.SecurityPolicy{})
+	err = f.kubeClient.DeleteAllOf(ctx, &securityv1alpha1.SecurityPolicy{}, client.InNamespace(metav1.NamespaceDefault))
 	if err != nil {
 		return fmt.Errorf("clean policies: %s", err)
 	}

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -113,7 +113,7 @@ func (f *Framework) CleanObjects(ctx context.Context, objects ...metav1.Object) 
 		}
 
 		err = wait.Poll(f.Interval(), f.Timeout(), func() (done bool, err error) {
-			var objKey = types.NamespacedName{Name: object.GetName()}
+			var objKey = types.NamespacedName{Name: object.GetName(), Namespace: object.GetNamespace()}
 			var obj = object.(runtime.Object)
 			var getErr = f.kubeClient.Get(ctx, objKey, obj.DeepCopyObject())
 			return errors.IsNotFound(getErr), nil


### PR DESCRIPTION
To support Kubernetes NetworkPolicy, we need to change endpoint and security as no namespace resource.
issue: #131 