### PR TITLE
Support PolicyTypes for SecurityPolicy

### DIFF
--- a/deploy/crds/security.lynx.smartx.com_securitypolicies.yaml
+++ b/deploy/crds/security.lynx.smartx.com_securitypolicies.yaml
@@ -295,6 +295,23 @@ spec:
                   - name
                   type: object
                 type: array
+              policyTypes:
+                description: List of rule types that the Security relates to. Valid
+                  options are "Ingress", "Egress", or "Ingress,Egress". If this field
+                  is not specified, it will default based on the existence of Ingress
+                  or Egress rules; policies that contain an Egress section are assumed
+                  to affect Egress, and all policies (whether or not they contain
+                  an Ingress section) are assumed to affect Ingress. If you want to
+                  write an egress-only policy, you must explicitly specify policyTypes
+                  [ "Egress" ]. Likewise, if you want to write a policy that specifies
+                  that no egress is allowed, you must specify a policyTypes value
+                  that include "Egress" (since such a policy would not include an
+                  Egress section and would otherwise default to just [ "Ingress" ]).
+                items:
+                  description: Policy Type string describes the NetworkPolicy type
+                    This type is beta-level in 1.8
+                  type: string
+                type: array
               symmetricMode:
                 description: SymmetricMode will generated symmetry rules for the policy.
                   Defaults to false.

--- a/pkg/apis/security/v1alpha1/helper.go
+++ b/pkg/apis/security/v1alpha1/helper.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Lynx Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// IsEnable returns whether SecurityPolicy ingress and egress should enable
+func (p *SecurityPolicy) IsEnable() (ingressEnabled bool, egressEnabled bool) {
+	for _, policyType := range p.Spec.PolicyTypes {
+		if policyType == networkingv1.PolicyTypeIngress {
+			ingressEnabled = true
+		}
+		if policyType == networkingv1.PolicyTypeEgress {
+			egressEnabled = true
+		}
+	}
+	// If no policyTypes are specified on a SecurityPolicy then
+	// by default Ingress will always be set and Egress will be
+	// set if the SecurityPolicy has any egress rules.
+	if !ingressEnabled && !egressEnabled {
+		ingressEnabled = true
+		if len(p.Spec.EgressRules) != 0 {
+			egressEnabled = true
+		}
+	}
+	return
+}

--- a/pkg/apis/security/v1alpha1/types.go
+++ b/pkg/apis/security/v1alpha1/types.go
@@ -54,6 +54,18 @@ type SecurityPolicySpec struct {
 	// List of egress rules to be applied to giving groups. If this field is empty
 	// then this SecurityPolicy limits all outgoing traffic.
 	EgressRules []Rule `json:"egressRules,omitempty"`
+
+	// List of rule types that the Security relates to.
+	// Valid options are "Ingress", "Egress", or "Ingress,Egress".
+	// If this field is not specified, it will default based on the existence of Ingress or Egress rules;
+	// policies that contain an Egress section are assumed to affect Egress, and all policies
+	// (whether or not they contain an Ingress section) are assumed to affect Ingress.
+	// If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+	// Likewise, if you want to write a policy that specifies that no egress is allowed,
+	// you must specify a policyTypes value that include "Egress" (since such a policy would not include
+	// an Egress section and would otherwise default to just [ "Ingress" ]).
+	// +optional
+	PolicyTypes []networkingv1.PolicyType `json:"policyTypes,omitempty"`
 }
 
 type AppliedTo struct {

--- a/pkg/apis/security/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/security/v1alpha1/zz_generated.deepcopy.go
@@ -318,6 +318,11 @@ func (in *SecurityPolicySpec) DeepCopyInto(out *SecurityPolicySpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PolicyTypes != nil {
+		in, out := &in.PolicyTypes, &out.PolicyTypes
+		*out = make([]v1.PolicyType, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/tests/e2e/cases/security_test.go
+++ b/tests/e2e/cases/security_test.go
@@ -19,12 +19,12 @@ package cases
 import (
 	"context"
 	"fmt"
-	networkingv1 "k8s.io/api/networking/v1"
 	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -530,6 +530,11 @@ func newPolicy(name, tier string, appliedGroup []string, endpoints []string) *se
 		AppliedTo: securityv1alpha1.AppliedTo{
 			EndpointGroups: appliedGroup,
 			Endpoints:      endpoints,
+		},
+		// Default enable both ingress and egress rules
+		PolicyTypes: []networkingv1.PolicyType{
+			networkingv1.PolicyTypeIngress,
+			networkingv1.PolicyTypeEgress,
 		},
 	}
 

--- a/tests/e2e/tools/e2ectl/command/policy.go
+++ b/tests/e2e/tools/e2ectl/command/policy.go
@@ -223,6 +223,10 @@ func addPolicy(f *framework.Framework, name string, tier string, appliedGroups s
 		AppliedTo: v1alpha1.AppliedTo{
 			EndpointGroups: strings.Split(appliedGroups, ","),
 		},
+		PolicyTypes: []networkingv1.PolicyType{
+			networkingv1.PolicyTypeIngress,
+			networkingv1.PolicyTypeEgress,
+		},
 	}
 
 	return f.SetupObjects(context.TODO(), policy)


### PR DESCRIPTION
**Why do we need this ?**
Kubernetes NetworkPolicy supports PolicyTypes, described below:
> Each NetworkPolicy includes a policyTypes list which may include either Ingress, Egress, or both. The policyTypes field indicates whether or not the given policy applies to ingress traffic to selected pod, egress traffic from selected pods, or both. If no policyTypes are specified on a NetworkPolicy then by default Ingress will always be set and Egress will be set if the NetworkPolicy has any egress rules.

To support Kubernetes NetworkPolicy #131 , we need add this field in SecurityPolicy.

**Dependent PR #133 Merge First**

