### PR TITLE
test(agentmonitor): extend timeout time for agent monitor test

### DIFF
--- a/pkg/monitor/agent_test.go
+++ b/pkg/monitor/agent_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 10
+	timeout  = time.Second * 60
 	interval = time.Millisecond * 250
 )
 


### PR DESCRIPTION
agent need more time to start with more complex datapath.